### PR TITLE
Fix Communication Handler not providing data

### DIFF
--- a/src/controller/ControllerCommunicator.ts
+++ b/src/controller/ControllerCommunicator.ts
@@ -28,16 +28,29 @@ export class ControllerCommunicator<
     }, CommunicationDataType.AppData_CONTROLLER);
   }
 
+  /** Promise indicating when communication between tp.games and the game have had first communication */
+  waitForLoad: Promise<void>;
+
+  /** If this value is true, tp.games and the game have communicated */
+  hasLoaded = false;
+
   /**
    * @param {boolean} autoReady - Indicates whether the controller should automatically become ready. (Wait 1 second before becoming ready)
    */
   constructor(autoReady = false) {
     super();
 
+    const { promise, resolve } = Promise.withResolvers<void>();
+
+    this.waitForLoad = promise;
+
     this.messageListener = (event) => this.messageHandler(event.data);
     window.addEventListener('message', this.messageListener);
 
     this.addAppMessageListener(({ data }) => {
+      resolve();
+      this.hasLoaded = true;
+
       this.hosterReady = data.hosterReady;
 
       this.devMode = data.devMode;

--- a/src/hoster/HosterCommunicator.ts
+++ b/src/hoster/HosterCommunicator.ts
@@ -36,15 +36,29 @@ export class HosterCommunicator<
     return this.playerStore.playerMap;
   }
 
+  /** Promise indicating when communication between tp.games and the game have had first communication */
+  waitForLoad: Promise<void>;
+
+  /** If this value is true, tp.games and the game have communicated */
+  hasLoaded = false;
+
   /**
    * @param {boolean} autoReady - Indicates whether the controller should automatically become ready. (Wait 1 second before becoming ready)
    */
   constructor(autoReady = false) {
     super();
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+
+    this.waitForLoad = promise;
+
     this.messageListener = (event) => this.messageHandler(event.data);
     window.addEventListener('message', this.messageListener);
 
     this.addAppMessageListener(({ data }) => {
+      resolve();
+      this.hasLoaded = true;
+
       this.playerStore.smartUpdatePlayers(data.players);
 
       this.devMode = data.devMode;

--- a/src/hoster/PlayerStore.ts
+++ b/src/hoster/PlayerStore.ts
@@ -70,6 +70,7 @@ export class PlayerStore {
     );
   }
 
+  /** For internal usage only */
   smartUpdatePlayers(dtos: PlayerDto[]) {
     const newConnectionIds = new Set(dtos.map((dto) => dto.connectionId));
 


### PR DESCRIPTION
The Communication Handler is currently not providing the necessary data, resulting in empty player and playerMap values. This pull request fixes the issue by adding a waitForLoad promise and a hasLoaded flag to indicate when communication between tp.games and the game has occurred. Additionally, the smartUpdatePlayers method in the PlayerStore class is now marked for internal usage only. This resolves issue #271.

<sub><a href="https://huly.app/guest/tpgames?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE3ZjRmN2YwMmQ4YTAzZmIyZjdmOWUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHVianVzdGluLXRwZ2FtZXMtNjcwNGM3ZjgtMWI2MmI5ZWUyNy1hOGY3N2MifQ.tBjmX02YV0kKg2Y1557on73fnHqlve6f6Zm1E7dE2kU">Huly&reg;: <b>CORE-272</b></a></sub>