### PR TITLE
Add game settings management and persistence

### DIFF
--- a/src/common/CommunicationDataTransfers.ts
+++ b/src/common/CommunicationDataTransfers.ts
@@ -1,12 +1,18 @@
 /* eslint-disable @typescript-eslint/ban-types */
 // TODO: need to be split between hoster and controller
 
+import { ControllerGlobalSettings } from '@/controller/ControllerDataPersistence';
+import { HosterGlobalSettings } from '@/hoster/HosterDataPersistence';
+
 import { PlayerDto } from './models/PlayerModel';
 
 export interface GameDataDefinition<C2H = unknown, H2C = unknown> {
   ControllerToHoster: C2H;
   HosterToController: H2C;
 }
+
+// G2P = Game to Platform
+// P2G = Platform to Game
 
 export enum CommunicationDataType {
   DEBUG = 'DEBUG',
@@ -33,6 +39,18 @@ export enum CommunicationDataType {
   END_GAME_CONTROLLER = 'END_GAME_CONTROLLER',
   RELOAD_GAME_HOSTER = 'RELOAD_GAME_HOSTER',
   RELOAD_GAME_CONTROLLER = 'RELOAD_GAME_CONTROLLER',
+
+  SET_GLOBAL_SETTING_HOSTER_G2P = 'SET_GLOBAL_SETTING_HOSTER_G2P',
+  SET_GLOBAL_SETTING_CONTROLLER_G2P = 'SET_GLOBAL_SETTING_CONTROLLER_G2P',
+
+  SET_GAME_STORAGE_HOSTER_G2P = 'SET_GAME_STORAGE_HOSTER_G2P',
+  SET_GAME_STORAGE_CONTROLLER_G2P = 'SET_GAME_STORAGE_CONTROLLER_G2P',
+
+  UPDATED_GLOBAL_SETTING_HOSTER_P2G = 'UPDATED_GLOBAL_SETTING_HOSTER_P2G',
+  UPDATED_GLOBAL_SETTING_CONTROLLER_P2G = 'UPDATED_GLOBAL_SETTING_CONTROLLER_P2G',
+
+  UPDATED_GAME_STORAGE_HOSTER_P2G = 'UPDATED_GAME_STORAGE_HOSTER_P2G',
+  UPDATED_GAME_STORAGE_CONTROLLER_P2G = 'UPDATED_GAME_STORAGE_CONTROLLER_P2G',
 }
 
 export interface CommunicationDataTransfersStructure {
@@ -58,6 +76,8 @@ export interface AppDataTransfer_HOSTER extends CommunicationDataTransfersStruct
     joinCode: string;
     devMode: boolean;
     lobbyGame: boolean;
+    globalSettings: HosterGlobalSettings;
+    gameStorage: Record<string, string | undefined>;
   };
 }
 
@@ -71,6 +91,8 @@ export interface AppDataTransfer_CONTROLLER extends CommunicationDataTransfersSt
     joinCode: string;
     devMode: boolean;
     lobbyGame: boolean;
+    globalSettings: ControllerGlobalSettings;
+    gameStorage: Record<string, string | undefined>;
   };
 }
 
@@ -191,6 +213,82 @@ export interface ReloadGame_CONTROLLER extends CommunicationDataTransfersStructu
   data: {};
 }
 
+export type SetGlobalSettingTransfer_HOSTER = {
+  [K in keyof HosterGlobalSettings]: {
+    type: CommunicationDataType.SET_GLOBAL_SETTING_HOSTER_G2P;
+    data: {
+      key: K;
+      value: HosterGlobalSettings[K];
+    };
+  };
+}[keyof HosterGlobalSettings];
+
+export type SetGlobalSettingTransfer_CONTROLLER = {
+  [K in keyof ControllerGlobalSettings]: {
+    type: CommunicationDataType.SET_GLOBAL_SETTING_CONTROLLER_G2P;
+    data: {
+      key: K;
+      value: ControllerGlobalSettings[K];
+    };
+  };
+}[keyof ControllerGlobalSettings];
+
+export interface SetGameSettingTransfer_HOSTER
+  extends CommunicationDataTransfersStructure {
+  type: CommunicationDataType.SET_GAME_STORAGE_HOSTER_G2P;
+  data: {
+    key: string;
+    value: unknown;
+  };
+}
+
+export interface SetGameSettingTransfer_CONTROLLER
+  extends CommunicationDataTransfersStructure {
+  type: CommunicationDataType.SET_GAME_STORAGE_CONTROLLER_G2P;
+  data: {
+    key: string;
+    value: unknown;
+  };
+}
+
+export type UpdatedGlobalSettingTransfer_HOSTER = {
+  [K in keyof HosterGlobalSettings]: {
+    type: CommunicationDataType.UPDATED_GLOBAL_SETTING_HOSTER_P2G;
+    data: {
+      key: K;
+      value: HosterGlobalSettings[K];
+    };
+  };
+}[keyof HosterGlobalSettings];
+
+export type UpdatedGlobalSettingTransfer_CONTROLLER = {
+  [K in keyof ControllerGlobalSettings]: {
+    type: CommunicationDataType.UPDATED_GLOBAL_SETTING_CONTROLLER_P2G;
+    data: {
+      key: K;
+      value: ControllerGlobalSettings[K];
+    };
+  };
+}[keyof ControllerGlobalSettings];
+
+export interface UpdatedGameSettingTransfer_HOSTER
+  extends CommunicationDataTransfersStructure {
+  type: CommunicationDataType.UPDATED_GAME_STORAGE_HOSTER_P2G;
+  data: {
+    key: string;
+    value: unknown;
+  };
+}
+
+export interface UpdatedGameSettingTransfer_CONTROLLER
+  extends CommunicationDataTransfersStructure {
+  type: CommunicationDataType.UPDATED_GAME_STORAGE_CONTROLLER_P2G;
+  data: {
+    key: string;
+    value: unknown;
+  };
+}
+
 // Transfer listings
 
 export type AppDataTransfer =
@@ -207,7 +305,15 @@ export type AppDataTransfer =
   | ReloadGame_CONTROLLER
   | PingTransfer_HOSTER
   | PongTransfer_CONTROLLER
-  | PongTransfer_HOSTER;
+  | PongTransfer_HOSTER
+  | SetGlobalSettingTransfer_HOSTER
+  | SetGlobalSettingTransfer_CONTROLLER
+  | SetGameSettingTransfer_HOSTER
+  | SetGameSettingTransfer_CONTROLLER
+  | UpdatedGlobalSettingTransfer_HOSTER
+  | UpdatedGlobalSettingTransfer_CONTROLLER
+  | UpdatedGameSettingTransfer_HOSTER
+  | UpdatedGameSettingTransfer_CONTROLLER;
 
 export type GameDataTransfer<T extends GameDataDefinition> =
   | GameActionTransfer_CONTROLLER<T>

--- a/src/controller/ControllerCommunicator.ts
+++ b/src/controller/ControllerCommunicator.ts
@@ -1,4 +1,7 @@
-import { MOBX_makeSimpleAutoObservable } from '@/common/utils/mobx/index.skip-barrel';
+import {
+  MOBX_makeSimpleAutoObservable,
+  smartUpdate,
+} from '@/common/utils/mobx/index.skip-barrel';
 
 import { BaseCommunicator } from '../common/BaseCommunicator';
 import {
@@ -8,6 +11,7 @@ import {
   GameDataDefinition,
   GameDataTransfer,
 } from '../common/CommunicationDataTransfers';
+import { ControllerDataPersistence } from './ControllerDataPersistence';
 
 export interface PingData {
   ping: number;
@@ -22,6 +26,8 @@ export class ControllerCommunicator<
     HosterToController: unknown;
   },
 > extends BaseCommunicator<TGameData> {
+  dataPersistence = new ControllerDataPersistence(this);
+
   /** This should not be used unless you know what you are doing */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   messageListener: (this: Window, ev: MessageEvent<any>) => any;
@@ -74,6 +80,18 @@ export class ControllerCommunicator<
       this.joinUrl = data.joinUrl;
 
       this.connectionId = data.connectionId;
+
+      if (!this.dataPersistence.globalSettings || !data.globalSettings) {
+        this.dataPersistence.globalSettings = data.globalSettings;
+      } else {
+        smartUpdate(this.dataPersistence.globalSettings, data.globalSettings);
+      }
+
+      if (!this.dataPersistence.gameStorage || !data.gameStorage) {
+        this.dataPersistence.gameStorage = data.gameStorage;
+      } else {
+        smartUpdate(this.dataPersistence.gameStorage, data.gameStorage);
+      }
     }, CommunicationDataType.AppData_CONTROLLER);
 
     this.sendAppMessage({

--- a/src/controller/ControllerDataPersistence.ts
+++ b/src/controller/ControllerDataPersistence.ts
@@ -1,0 +1,71 @@
+import { makeAutoObservable } from 'mobx';
+
+import {
+  CommunicationDataType,
+  GameDataDefinition,
+} from '@/common/CommunicationDataTransfers';
+
+import { ControllerCommunicator } from './ControllerCommunicator';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ControllerGlobalSettings {
+  soundFxVolume: number;
+}
+
+export class ControllerDataPersistence<TGameData extends GameDataDefinition> {
+  /** global settings, null value until loaded */
+  globalSettings: ControllerGlobalSettings | null = null;
+
+  /** game storage, null value until loaded */
+  gameStorage: Record<string, string | undefined> | null = null;
+
+  constructor(private controllerCommunicator: ControllerCommunicator<TGameData>) {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  setGlobalSetting<T extends keyof ControllerGlobalSettings>(
+    key: T,
+    value: ControllerGlobalSettings[T],
+  ): Promise<void> {
+    this.controllerCommunicator.sendAppMessage({
+      type: CommunicationDataType.SET_GLOBAL_SETTING_CONTROLLER_G2P,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this is safe
+      data: { key, value } as any,
+    });
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+
+    const listener = this.controllerCommunicator.addAppMessageListener((message) => {
+      if (message.type !== CommunicationDataType.UPDATED_GLOBAL_SETTING_CONTROLLER_P2G)
+        return;
+
+      if (message.data.key !== key) return;
+
+      resolve();
+      listener.destroy();
+    });
+
+    return promise;
+  }
+
+  setGameStorage(key: string, value: string | undefined): Promise<void> {
+    this.controllerCommunicator.sendAppMessage({
+      type: CommunicationDataType.SET_GAME_STORAGE_CONTROLLER_G2P,
+      data: { key, value },
+    });
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+
+    const listener = this.controllerCommunicator.addAppMessageListener((message) => {
+      if (message.type !== CommunicationDataType.UPDATED_GAME_STORAGE_CONTROLLER_P2G)
+        return;
+
+      if (message.data.key !== key) return;
+
+      resolve();
+      listener.destroy();
+    });
+
+    return promise;
+  }
+}

--- a/src/hoster/HosterCommunicator.ts
+++ b/src/hoster/HosterCommunicator.ts
@@ -1,7 +1,10 @@
 import { runInAction } from 'mobx';
 
 import { PlayerModel } from '@/common/models/PlayerModel';
-import { MOBX_makeSimpleAutoObservable } from '@/common/utils/mobx/index.skip-barrel';
+import {
+  MOBX_makeSimpleAutoObservable,
+  smartUpdate,
+} from '@/common/utils/mobx/index.skip-barrel';
 
 import { BaseCommunicator } from '../common/BaseCommunicator';
 import {
@@ -10,6 +13,7 @@ import {
   GameDataDefinition,
   GameDataTransfer,
 } from '../common/CommunicationDataTransfers';
+import { HosterDataPersistence } from './HosterDataPersistence';
 import { PlayerStore } from './PlayerStore';
 
 export interface PlayerPingData {
@@ -25,6 +29,8 @@ export class HosterCommunicator<
   },
 > extends BaseCommunicator<GameDataDefinition> {
   playerStore = new PlayerStore(this);
+
+  dataPersistence = new HosterDataPersistence(this);
 
   playerPingMap: Map<string, PlayerPingData> = new Map();
   playerPingListeners: { listener: (playerPingData: PlayerPingData) => void }[] = [];
@@ -89,6 +95,18 @@ export class HosterCommunicator<
         this.joinUrl = data.joinUrl;
 
         this.connectionId = data.connectionId;
+
+        if (!this.dataPersistence.globalSettings || !data.globalSettings) {
+          this.dataPersistence.globalSettings = data.globalSettings;
+        } else {
+          smartUpdate(this.dataPersistence.globalSettings, data.globalSettings);
+        }
+
+        if (!this.dataPersistence.gameStorage || !data.gameStorage) {
+          this.dataPersistence.gameStorage = data.gameStorage;
+        } else {
+          smartUpdate(this.dataPersistence.gameStorage, data.gameStorage);
+        }
       });
     }, CommunicationDataType.AppData_HOSTER);
 

--- a/src/hoster/HosterDataPersistence.ts
+++ b/src/hoster/HosterDataPersistence.ts
@@ -1,0 +1,76 @@
+import { makeAutoObservable } from 'mobx';
+
+import { CommunicationDataType } from '@/common/CommunicationDataTransfers';
+
+import { HosterCommunicator } from './HosterCommunicator';
+
+export enum MaturityLevel {
+  Everyone = 'Everyone',
+  Teen = 'Teen',
+  Mature = 'Mature',
+}
+
+export interface HosterGlobalSettings {
+  soundFxVolume: number;
+  musicVolume: number;
+  narrationVolume: number;
+
+  maturityLevel: MaturityLevel;
+}
+
+export class HosterDataPersistence {
+  /** global settings, null value until loaded */
+  globalSettings: HosterGlobalSettings | null = null;
+
+  /** game storage, null value until loaded */
+  gameStorage: Record<string, string | undefined> | null = null;
+
+  constructor(private hosterCommunicator: HosterCommunicator) {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  setGlobalSetting<T extends keyof HosterGlobalSettings>(
+    key: T,
+    value: HosterGlobalSettings[T],
+  ): Promise<void> {
+    this.hosterCommunicator.sendAppMessage({
+      type: CommunicationDataType.SET_GLOBAL_SETTING_HOSTER_G2P,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this is safe
+      data: { key, value } as any,
+    });
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+
+    const listener = this.hosterCommunicator.addAppMessageListener((message) => {
+      if (message.type !== CommunicationDataType.UPDATED_GLOBAL_SETTING_HOSTER_P2G)
+        return;
+
+      if (message.data.key !== key) return;
+
+      resolve();
+      listener.destroy();
+    });
+
+    return promise;
+  }
+
+  setGameStorage(key: string, value: string | undefined): Promise<void> {
+    this.hosterCommunicator.sendAppMessage({
+      type: CommunicationDataType.SET_GAME_STORAGE_HOSTER_G2P,
+      data: { key, value },
+    });
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+
+    const listener = this.hosterCommunicator.addAppMessageListener((message) => {
+      if (message.type !== CommunicationDataType.UPDATED_GAME_STORAGE_HOSTER_P2G) return;
+
+      if (message.data.key !== key) return;
+
+      resolve();
+      listener.destroy();
+    });
+
+    return promise;
+  }
+}


### PR DESCRIPTION
Implement game settings functionality in the core library, allowing for game-specific settings to be read and written. Introduce data persistence for global settings and game storage, ensuring settings are stored and retrieved correctly. This addresses issues #248 and #247.