### PR TITLE
Add access to player info through core lib on controller

### DIFF
--- a/src/common/CommunicationDataTransfers.ts
+++ b/src/common/CommunicationDataTransfers.ts
@@ -87,6 +87,7 @@ export interface AppDataTransfer_CONTROLLER extends CommunicationDataTransfersSt
   data: {
     hosterReady: boolean;
     connectionId: string;
+    player: PlayerDto;
     joinUrl: string;
     joinCode: string;
     devMode: boolean;

--- a/src/controller/ControllerCommunicator.ts
+++ b/src/controller/ControllerCommunicator.ts
@@ -1,3 +1,4 @@
+import { PlayerDto } from '@/common/models/PlayerModel';
 import {
   MOBX_makeSimpleAutoObservable,
   smartUpdate,
@@ -26,6 +27,7 @@ export class ControllerCommunicator<
     HosterToController: unknown;
   },
 > extends BaseCommunicator<TGameData> {
+  player: PlayerDto | null = null;
   dataPersistence = new ControllerDataPersistence(this);
 
   /** This should not be used unless you know what you are doing */
@@ -91,6 +93,12 @@ export class ControllerCommunicator<
         this.dataPersistence.gameStorage = data.gameStorage;
       } else {
         smartUpdate(this.dataPersistence.gameStorage, data.gameStorage);
+      }
+
+      if (!this.player || !data.player) {
+        this.player = data.player;
+      } else {
+        smartUpdate(this.player, data.player);
       }
     }, CommunicationDataType.AppData_CONTROLLER);
 


### PR DESCRIPTION
Enhance the controller by integrating access to player information via the core library. This change allows the controller to manage player data effectively.

Fixes #309