### PR TITLE
Add ping-adjusted controller hoster time

### DIFF
--- a/src/controller/ControllerCommunicator.ts
+++ b/src/controller/ControllerCommunicator.ts
@@ -19,6 +19,10 @@ export interface PingData {
   lastPoll: number;
   timeSinceStart: number;
   timeSinceStartPingAdjusted: number;
+  /** Hoster clock timestamp when the latest pong was sent. */
+  hosterTime: number;
+  /** Estimated hoster timestamp when the latest pong reached this controller. */
+  hosterTimePingAdjusted: number;
 }
 
 export class ControllerCommunicator<
@@ -44,6 +48,27 @@ export class ControllerCommunicator<
   /** Current ping (time from hoster to controller and controller to hoster combined) */
   pingData: PingData | null = null;
   pingListeners: { listener: (pingData: PingData) => void }[] = [];
+
+  /**
+   * Estimated current hoster timestamp in milliseconds.
+   *
+   * The latest host timestamp is adjusted by half the measured round-trip time
+   * and advanced using elapsed controller time between ping samples. Call this
+   * method on demand; it does not schedule timer updates.
+   *
+   * @returns The estimated hoster clock, or `null` before the first completed
+   * ping exchange.
+   */
+  getHosterTime(): number | null {
+    if (!this.pingData) {
+      return null;
+    }
+
+    return (
+      this.pingData.hosterTimePingAdjusted +
+      (Date.now() - this.pingData.lastPoll)
+    );
+  }
 
   addHosterReadyListener(listener: (ready: boolean) => void) {
     return this.addAppMessageListener(({ data }) => {
@@ -143,11 +168,15 @@ export class ControllerCommunicator<
     }, CommunicationDataType.PING_HOSTER);
 
     this.addAppMessageListener(({ data }) => {
+      const lastPoll = Date.now();
+      const oneWayDelay = data.pingMs / 2;
       const pingData = {
         ping: data.pingMs,
-        lastPoll: Date.now(),
+        lastPoll,
         timeSinceStart: data.timeSinceStart,
-        timeSinceStartPingAdjusted: data.timeSinceStart + data.pingMs / 2,
+        timeSinceStartPingAdjusted: data.timeSinceStart + oneWayDelay,
+        hosterTime: data.hosterTime,
+        hosterTimePingAdjusted: data.hosterTime + oneWayDelay,
       };
 
       this.pingData = pingData;

--- a/test/src/controller-time.test.ts
+++ b/test/src/controller-time.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CommunicationDataType,
+  ControllerCommunicator,
+  type PingData,
+} from '@/index';
+
+describe('ControllerCommunicator hoster time', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      parent: {
+        postMessage: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns no hoster time before the first ping sample', () => {
+    const communicator = new ControllerCommunicator();
+
+    expect(communicator.getHosterTime()).toBeNull();
+
+    communicator.destructor();
+  });
+
+  it('retains and advances the half-round-trip-adjusted hoster time', () => {
+    const communicator = new ControllerCommunicator();
+    const onPing = vi.fn<(pingData: PingData) => void>();
+    communicator.addPingListener(onPing);
+
+    communicator.messageHandler({
+      type: CommunicationDataType.PONG_HOSTER,
+      data: {
+        id: 'ping-1',
+        playerId: 'player-1',
+        pingMs: 40,
+        timeSinceStart: 5_000,
+        hosterTime: 1_000_000,
+      },
+    });
+
+    expect(communicator.pingData).toEqual({
+      ping: 40,
+      lastPoll: 10_000,
+      timeSinceStart: 5_000,
+      timeSinceStartPingAdjusted: 5_020,
+      hosterTime: 1_000_000,
+      hosterTimePingAdjusted: 1_000_020,
+    });
+    expect(onPing).toHaveBeenCalledWith(communicator.pingData);
+    expect(communicator.getHosterTime()).toBe(1_000_020);
+
+    vi.advanceTimersByTime(250);
+
+    expect(communicator.getHosterTime()).toBe(1_000_270);
+
+    communicator.destructor();
+  });
+});

--- a/test/src/controller-time.test.ts
+++ b/test/src/controller-time.test.ts
@@ -7,9 +7,27 @@ import {
 } from '@/index';
 
 describe('ControllerCommunicator hoster time', () => {
+  let installedPromiseWithResolvers = false;
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);
+    if (!Promise.withResolvers) {
+      Object.defineProperty(Promise, 'withResolvers', {
+        configurable: true,
+        value: <T>() => {
+          let resolve!: (value: T | PromiseLike<T>) => void;
+          let reject!: (reason?: unknown) => void;
+          const promise = new Promise<T>((promiseResolve, promiseReject) => {
+            resolve = promiseResolve;
+            reject = promiseReject;
+          });
+
+          return { promise, resolve, reject };
+        },
+      });
+      installedPromiseWithResolvers = true;
+    }
     vi.stubGlobal('window', {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
@@ -20,6 +38,10 @@ describe('ControllerCommunicator hoster time', () => {
   });
 
   afterEach(() => {
+    if (installedPromiseWithResolvers) {
+      Reflect.deleteProperty(Promise, 'withResolvers');
+      installedPromiseWithResolvers = false;
+    }
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
Fixes #308

## What changed

- retain the hoster's raw timestamp from each completed controller ping exchange
- expose a half-round-trip-adjusted host timestamp in `PingData`
- add `getHosterTime()` to advance the latest adjusted sample using elapsed controller time
- return `null` until the controller has received its first hoster pong
- add deterministic fake-clock coverage for the pre-ping and advancing-clock contracts
- keep the focused test compatible with the workflow's Node 20 runtime using a test-local `Promise.withResolvers` shim

## Root cause and impact

`PONG_HOSTER` already carried `hosterTime`, but `ControllerCommunicator` discarded it while constructing `PingData`. Controllers therefore had no supported way to estimate the hoster's current wall-clock time. This preserves the protocol value and exposes both the raw and latency-adjusted forms.

## Verification

- Red-first: the new focused tests failed before implementation because `getHosterTime()` and the host timestamp fields did not exist
- `npx -y node@20.10.0 node_modules/vitest/vitest.mjs run test/src/controller-time.test.ts` — 2 tests passed under the hosted workflow's Node version
- `node_modules/.bin/vitest run` — 6 files, 24 tests passed
- `corepack yarn coverage` — 6 files, 24 tests passed
- `node_modules/.bin/eslint src/controller/ControllerCommunicator.ts test/src/controller-time.test.ts` — passed (existing React-detection warning only)
- focused strict TypeScript config without the repository's broken project reference — passed
- `corepack yarn build` — passed and generated the expected public declaration
- `git diff --check` — passed

The first hosted run exposed that the existing communicator constructor uses `Promise.withResolvers`, unavailable on the workflow's Node 20.10 runtime. The test now installs and removes a local compatibility shim; the production implementation is unchanged by that follow-up.

`corepack yarn type-check` remains blocked by the repository's pre-existing `TS6305` error: `vite.config.d.ts` has not been built from `vite.config.ts`. This same error reproduces on the unchanged baseline.

## Demo

This is a non-visual library API change. Run `node_modules/.bin/vitest run test/src/controller-time.test.ts`; the second test demonstrates a 40 ms round trip producing a 20 ms host-clock adjustment, followed by live clock advancement as controller time moves forward.