### PR TITLE
Add opt-in game message delivery confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,29 @@
 This exists as a library used for creating games for the TP Games platform.
 
 This is imported to the game template and used primary to interface with the connection bridge and to get information sent to the platform along with communicating between the controllers and host devices.
+
+## Delivery confirmation
+
+Game messages remain fire-and-forget by default. Pass delivery options to wait until
+the receiving game iframe acknowledges a message:
+
+```ts
+const receipt = await controller.sendGameMessage(
+  { action: 'buzz' },
+  { timeoutMs: 3_000 },
+);
+
+const receipts = await hoster.broadcastGameMessage(
+  { notice: 'Vote now' },
+  { timeoutMs: 3_000 },
+);
+```
+
+The same options are available on `hoster.sendGameMessage` and
+`smartPlayer.sendMessage`. Confirmed broadcasts wait for every connected recipient.
+Failures reject with `GameMessageDeliveryError`; inspect its `code` for `timeout`,
+`recipient-unavailable`, or `communicator-destroyed`.
+
+Delivery confirmation requires a compatible core version in both the sending and
+receiving game iframe. `__tpgCoreDelivery` is reserved for the internal
+acknowledgement protocol and should not be used as a top-level game payload field.

--- a/src/common/BaseCommunicator.ts
+++ b/src/common/BaseCommunicator.ts
@@ -1,10 +1,26 @@
 import {
   CommunicationDataTransfer,
   CommunicationDataType,
+  ConfirmedGameMessageEnvelope,
+  DEFAULT_GAME_MESSAGE_DELIVERY_TIMEOUT_MS,
   GameDataTransfer,
+  GameMessageAcknowledgementEnvelope,
+  GameMessageDeliveryError,
+  GameMessageDeliveryOptions,
+  GameMessageDeliveryReceipt,
   isCommunicationDataTransfer,
+  isGameMessageDeliveryEnvelope,
 } from './CommunicationDataTransfers';
 import { messageParent } from './utils/iFrameMessenger';
+
+interface PendingGameMessageDelivery {
+  recipientId: string;
+  timeoutMs: number;
+  timeout: ReturnType<typeof setTimeout>;
+  cleanups: Set<() => void>;
+  resolve: (receipt: GameMessageDeliveryReceipt) => void;
+  reject: (error: GameMessageDeliveryError) => void;
+}
 
 /**
  * Base class for communicators in the game core.
@@ -14,6 +30,9 @@ export abstract class BaseCommunicator<
   TGameData extends { ControllerToHoster: unknown; HosterToController: unknown },
 > {
   connectionId: string | null = null;
+
+  #deliverySequence = 0;
+  #pendingGameMessageDeliveries = new Map<string, PendingGameMessageDelivery>();
 
   /**
    * Array of app message listeners.
@@ -130,5 +149,178 @@ export abstract class BaseCommunicator<
         this.gameMessageListeners.splice(index, 1);
       },
     };
+  }
+
+  protected createConfirmedGameMessage<TPayload>(
+    payload: TPayload,
+    recipientId: string,
+    options: GameMessageDeliveryOptions,
+  ): {
+    envelope: ConfirmedGameMessageEnvelope<TPayload>;
+    delivery: Promise<GameMessageDeliveryReceipt>;
+  } {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_GAME_MESSAGE_DELIVERY_TIMEOUT_MS;
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new RangeError('Game message delivery timeout must be greater than 0.');
+    }
+
+    const messageId = this.createGameMessageDeliveryId();
+    const { promise, resolve, reject } =
+      Promise.withResolvers<GameMessageDeliveryReceipt>();
+    const timeout = setTimeout(() => {
+      const pending = this.#pendingGameMessageDeliveries.get(messageId);
+      if (!pending) return;
+
+      this.#pendingGameMessageDeliveries.delete(messageId);
+      this.runGameMessageDeliveryCleanups(pending);
+      pending.reject(
+        new GameMessageDeliveryError(
+          'timeout',
+          messageId,
+          pending.recipientId,
+          pending.timeoutMs,
+        ),
+      );
+    }, timeoutMs);
+
+    this.#pendingGameMessageDeliveries.set(messageId, {
+      recipientId,
+      timeoutMs,
+      timeout,
+      cleanups: new Set(),
+      resolve,
+      reject,
+    });
+
+    return {
+      envelope: {
+        __tpgCoreDelivery: {
+          version: 1,
+          kind: 'message',
+          messageId,
+        },
+        payload,
+      },
+      delivery: promise,
+    };
+  }
+
+  protected createUnavailableGameMessageDelivery(
+    recipientId: string,
+  ): Promise<GameMessageDeliveryReceipt> {
+    const messageId = this.createGameMessageDeliveryId();
+    return Promise.reject(
+      new GameMessageDeliveryError('recipient-unavailable', messageId, recipientId),
+    );
+  }
+
+  protected handleGameMessageAcknowledgement(
+    payload: unknown,
+    senderId?: string,
+  ): boolean {
+    if (
+      !isGameMessageDeliveryEnvelope(payload) ||
+      payload.__tpgCoreDelivery.kind !== 'acknowledgement'
+    ) {
+      return false;
+    }
+
+    const { messageId } = payload.__tpgCoreDelivery;
+    const pending = this.#pendingGameMessageDeliveries.get(messageId);
+    if (!pending || (senderId && pending.recipientId !== senderId)) {
+      return true;
+    }
+
+    clearTimeout(pending.timeout);
+    this.#pendingGameMessageDeliveries.delete(messageId);
+    this.runGameMessageDeliveryCleanups(pending);
+    pending.resolve({
+      messageId,
+      recipientId: pending.recipientId,
+      confirmedAt: Date.now(),
+    });
+    return true;
+  }
+
+  protected unwrapConfirmedGameMessage<TPayload>(
+    payload: TPayload | ConfirmedGameMessageEnvelope<TPayload>,
+  ):
+    | { confirmed: false; payload: TPayload }
+    | { confirmed: true; messageId: string; payload: TPayload } {
+    if (
+      !isGameMessageDeliveryEnvelope(payload) ||
+      payload.__tpgCoreDelivery.kind !== 'message'
+    ) {
+      return { confirmed: false, payload: payload as TPayload };
+    }
+
+    const envelope = payload as ConfirmedGameMessageEnvelope<TPayload>;
+    return {
+      confirmed: true,
+      messageId: envelope.__tpgCoreDelivery.messageId,
+      payload: envelope.payload,
+    };
+  }
+
+  protected createGameMessageAcknowledgement(
+    messageId: string,
+  ): GameMessageAcknowledgementEnvelope {
+    return {
+      __tpgCoreDelivery: {
+        version: 1,
+        kind: 'acknowledgement',
+        messageId,
+      },
+    };
+  }
+
+  protected addGameMessageDeliveryCleanup(messageId: string, cleanup: () => void) {
+    const pending = this.#pendingGameMessageDeliveries.get(messageId);
+    if (!pending) {
+      cleanup();
+      return;
+    }
+
+    pending.cleanups.add(cleanup);
+  }
+
+  protected rejectGameMessageDelivery(
+    messageId: string,
+    code: Exclude<GameMessageDeliveryError['code'], 'timeout'>,
+  ) {
+    const pending = this.#pendingGameMessageDeliveries.get(messageId);
+    if (!pending) return;
+
+    clearTimeout(pending.timeout);
+    this.#pendingGameMessageDeliveries.delete(messageId);
+    this.runGameMessageDeliveryCleanups(pending);
+    pending.reject(new GameMessageDeliveryError(code, messageId, pending.recipientId));
+  }
+
+  protected rejectPendingGameMessageDeliveries() {
+    for (const [messageId, pending] of this.#pendingGameMessageDeliveries) {
+      clearTimeout(pending.timeout);
+      this.runGameMessageDeliveryCleanups(pending);
+      pending.reject(
+        new GameMessageDeliveryError(
+          'communicator-destroyed',
+          messageId,
+          pending.recipientId,
+        ),
+      );
+    }
+    this.#pendingGameMessageDeliveries.clear();
+  }
+
+  private createGameMessageDeliveryId() {
+    this.#deliverySequence += 1;
+    return `${Date.now().toString(36)}-${this.#deliverySequence.toString(36)}-${Math.random().toString(36).slice(2)}`;
+  }
+
+  private runGameMessageDeliveryCleanups(pending: PendingGameMessageDelivery) {
+    for (const cleanup of pending.cleanups) {
+      cleanup();
+    }
+    pending.cleanups.clear();
   }
 }

--- a/src/common/CommunicationDataTransfers.ts
+++ b/src/common/CommunicationDataTransfers.ts
@@ -11,6 +11,92 @@ export interface GameDataDefinition<C2H = unknown, H2C = unknown> {
   HosterToController: H2C;
 }
 
+export const DEFAULT_GAME_MESSAGE_DELIVERY_TIMEOUT_MS = 5_000;
+
+export interface GameMessageDeliveryOptions {
+  /**
+   * Maximum time to wait for the receiving game iframe to acknowledge the
+   * message.
+   */
+  timeoutMs?: number;
+}
+
+export interface GameMessageDeliveryReceipt {
+  messageId: string;
+  recipientId: string;
+  confirmedAt: number;
+}
+
+export type GameMessageDeliveryErrorCode =
+  | 'timeout'
+  | 'recipient-unavailable'
+  | 'communicator-destroyed';
+
+export class GameMessageDeliveryError extends Error {
+  readonly name = 'GameMessageDeliveryError';
+
+  constructor(
+    readonly code: GameMessageDeliveryErrorCode,
+    readonly messageId: string,
+    readonly recipientId: string,
+    readonly timeoutMs?: number,
+  ) {
+    super(
+      code === 'timeout'
+        ? `Game message ${messageId} was not acknowledged by ${recipientId} within ${timeoutMs}ms.`
+        : code === 'recipient-unavailable'
+          ? `Game message ${messageId} cannot be delivered because ${recipientId} is unavailable.`
+          : `Game message ${messageId} was cancelled because the communicator was destroyed.`,
+    );
+  }
+}
+
+interface GameMessageDeliveryMetadata {
+  version: 1;
+  kind: 'message' | 'acknowledgement';
+  messageId: string;
+}
+
+export interface ConfirmedGameMessageEnvelope<TPayload> {
+  __tpgCoreDelivery: GameMessageDeliveryMetadata & { kind: 'message' };
+  payload: TPayload;
+}
+
+export interface GameMessageAcknowledgementEnvelope {
+  __tpgCoreDelivery: GameMessageDeliveryMetadata & {
+    kind: 'acknowledgement';
+  };
+}
+
+export type GameMessageDeliveryEnvelope<TPayload> =
+  | ConfirmedGameMessageEnvelope<TPayload>
+  | GameMessageAcknowledgementEnvelope;
+
+export function isGameMessageDeliveryEnvelope(
+  value: unknown,
+): value is GameMessageDeliveryEnvelope<unknown> {
+  if (typeof value !== 'object' || value === null || !('__tpgCoreDelivery' in value)) {
+    return false;
+  }
+
+  const metadata = value.__tpgCoreDelivery;
+  if (
+    typeof metadata !== 'object' ||
+    metadata === null ||
+    !('version' in metadata) ||
+    metadata.version !== 1 ||
+    !('kind' in metadata) ||
+    (metadata.kind !== 'message' && metadata.kind !== 'acknowledgement') ||
+    !('messageId' in metadata) ||
+    typeof metadata.messageId !== 'string' ||
+    metadata.messageId.length === 0
+  ) {
+    return false;
+  }
+
+  return metadata.kind === 'acknowledgement' || 'payload' in value;
+}
+
 // G2P = Game to Platform
 // P2G = Platform to Game
 

--- a/src/controller/ControllerCommunicator.ts
+++ b/src/controller/ControllerCommunicator.ts
@@ -11,6 +11,9 @@ import {
   GameActionTransfer_CONTROLLER,
   GameDataDefinition,
   GameDataTransfer,
+  GameMessageDeliveryOptions,
+  GameMessageDeliveryReceipt,
+  isCommunicationDataTransfer,
 } from '../common/CommunicationDataTransfers';
 import { ControllerDataPersistence } from './ControllerDataPersistence';
 
@@ -64,10 +67,7 @@ export class ControllerCommunicator<
       return null;
     }
 
-    return (
-      this.pingData.hosterTimePingAdjusted +
-      (Date.now() - this.pingData.lastPoll)
-    );
+    return this.pingData.hosterTimePingAdjusted + (Date.now() - this.pingData.lastPoll);
   }
 
   addHosterReadyListener(listener: (ready: boolean) => void) {
@@ -153,6 +153,7 @@ export class ControllerCommunicator<
    */
   destructor() {
     window.removeEventListener('message', this.messageListener);
+    this.rejectPendingGameMessageDeliveries();
   }
 
   private setupPingPong() {
@@ -215,7 +216,30 @@ export class ControllerCommunicator<
    * Sends a game message to the hoster.
    * @param data The game data to be sent.
    */
-  sendGameMessage(data: TGameData['ControllerToHoster']) {
+  sendGameMessage(data: TGameData['ControllerToHoster']): void;
+  sendGameMessage(
+    data: TGameData['ControllerToHoster'],
+    options: GameMessageDeliveryOptions,
+  ): Promise<GameMessageDeliveryReceipt>;
+  sendGameMessage(
+    data: TGameData['ControllerToHoster'],
+    options?: GameMessageDeliveryOptions,
+  ): void | Promise<GameMessageDeliveryReceipt> {
+    if (options) {
+      const { envelope, delivery } = this.createConfirmedGameMessage(
+        data,
+        'hoster',
+        options,
+      );
+      this.sendMessage({
+        type: CommunicationDataType.GAME_ACTION_CONTROLLER,
+        data: {
+          payload: envelope,
+        },
+      });
+      return delivery;
+    }
+
     this.sendMessage({
       type: CommunicationDataType.GAME_ACTION_CONTROLLER,
       data: {
@@ -277,10 +301,45 @@ export class ControllerCommunicator<
 
   /** This should not be used unless you know what you are doing */
   messageHandler(message: unknown) {
-    super.messageHandler(message);
+    if (!isCommunicationDataTransfer<TGameData>(message)) {
+      throw new Error('Invalid data transfer');
+    }
 
+    if (
+      message.type === CommunicationDataType.GAME_ACTION_RESPONSE_CONTROLLER &&
+      this.handleGameMessageAcknowledgement(message.data.payload)
+    ) {
+      return;
+    }
+
+    let normalizedMessage = message;
     if (message.type === CommunicationDataType.GAME_ACTION_RESPONSE_CONTROLLER) {
-      this.gameMessageListeners.forEach((callbackfn) => callbackfn.listener(message));
+      const incoming = this.unwrapConfirmedGameMessage(message.data.payload);
+      if (incoming.confirmed) {
+        this.sendMessage({
+          type: CommunicationDataType.GAME_ACTION_CONTROLLER,
+          data: {
+            payload: this.createGameMessageAcknowledgement(incoming.messageId),
+          },
+        });
+        normalizedMessage = {
+          ...message,
+          data: {
+            ...message.data,
+            payload: incoming.payload,
+          },
+        };
+      }
+    }
+
+    super.messageHandler(normalizedMessage);
+
+    if (
+      normalizedMessage.type === CommunicationDataType.GAME_ACTION_RESPONSE_CONTROLLER
+    ) {
+      this.gameMessageListeners.forEach((callbackfn) =>
+        callbackfn.listener(normalizedMessage),
+      );
       return;
     }
   }

--- a/src/hoster/HosterCommunicator.ts
+++ b/src/hoster/HosterCommunicator.ts
@@ -12,6 +12,9 @@ import {
   GameActionResponseTransfer_HOSTER,
   GameDataDefinition,
   GameDataTransfer,
+  GameMessageDeliveryOptions,
+  GameMessageDeliveryReceipt,
+  isCommunicationDataTransfer,
 } from '../common/CommunicationDataTransfers';
 import { HosterDataPersistence } from './HosterDataPersistence';
 import { PlayerStore } from './PlayerStore';
@@ -136,6 +139,7 @@ export class HosterCommunicator<
    */
   destructor() {
     window.removeEventListener('message', this.messageListener);
+    this.rejectPendingGameMessageDeliveries();
   }
 
   /**
@@ -244,7 +248,53 @@ export class HosterCommunicator<
    * @param data The game data to send.
    * @param userId The ID of the user to send the message to.
    */
-  sendGameMessage(data: TGameData['HosterToController'], userId: string) {
+  sendGameMessage(data: TGameData['HosterToController'], userId: string): void;
+  sendGameMessage(
+    data: TGameData['HosterToController'],
+    userId: string,
+    options: GameMessageDeliveryOptions,
+  ): Promise<GameMessageDeliveryReceipt>;
+  sendGameMessage(
+    data: TGameData['HosterToController'],
+    userId: string,
+    options?: GameMessageDeliveryOptions,
+  ): void | Promise<GameMessageDeliveryReceipt> {
+    if (options) {
+      const player = this.playerMap.get(userId);
+      if (!player?.hasConnection) {
+        return this.createUnavailableGameMessageDelivery(userId);
+      }
+
+      const { envelope, delivery } = this.createConfirmedGameMessage(
+        data,
+        userId,
+        options,
+      );
+      const { messageId } = envelope.__tpgCoreDelivery;
+      const connectionDisposer = player.addConnectionListener((hasConnection) => {
+        if (!hasConnection) {
+          this.rejectGameMessageDelivery(messageId, 'recipient-unavailable');
+        }
+      });
+      const kickedListener = this.playerStore.addPlayerKickedListener((kickedPlayer) => {
+        if (kickedPlayer.connectionId === userId) {
+          this.rejectGameMessageDelivery(messageId, 'recipient-unavailable');
+        }
+      });
+      this.addGameMessageDeliveryCleanup(messageId, () => {
+        connectionDisposer();
+        kickedListener.destroy();
+      });
+      this.sendMessage({
+        type: CommunicationDataType.GAME_ACTION_HOSTER,
+        data: {
+          to: userId,
+          payload: envelope,
+        },
+      });
+      return delivery;
+    }
+
     this.sendMessage({
       type: CommunicationDataType.GAME_ACTION_HOSTER,
       data: {
@@ -259,7 +309,23 @@ export class HosterCommunicator<
    *
    * @param data The game message data to be sent.
    */
-  broadcastGameMessage(data: TGameData['HosterToController']) {
+  broadcastGameMessage(data: TGameData['HosterToController']): void;
+  broadcastGameMessage(
+    data: TGameData['HosterToController'],
+    options: GameMessageDeliveryOptions,
+  ): Promise<GameMessageDeliveryReceipt[]>;
+  broadcastGameMessage(
+    data: TGameData['HosterToController'],
+    options?: GameMessageDeliveryOptions,
+  ): void | Promise<GameMessageDeliveryReceipt[]> {
+    if (options) {
+      return Promise.all(
+        this.players
+          .filter((player) => player.hasConnection)
+          .map((player) => this.sendGameMessage(data, player.connectionId, options)),
+      );
+    }
+
     // TODO: create a dedicated method for broadcasting messages
     // such that less messages are sent across the iframe
     for (const player of this.players) {
@@ -320,10 +386,44 @@ export class HosterCommunicator<
 
   /** This should not be used unless you know what you are doing */
   messageHandler(message: unknown) {
-    super.messageHandler(message);
+    if (!isCommunicationDataTransfer<TGameData>(message)) {
+      throw new Error('Invalid data transfer');
+    }
 
+    if (
+      message.type === CommunicationDataType.GAME_ACTION_RESPONSE_HOSTER &&
+      this.handleGameMessageAcknowledgement(message.data.payload, message.data.from)
+    ) {
+      return;
+    }
+
+    let normalizedMessage = message;
     if (message.type === CommunicationDataType.GAME_ACTION_RESPONSE_HOSTER) {
-      this.gameMessageListeners.forEach((callbackfn) => callbackfn.listener(message));
+      const incoming = this.unwrapConfirmedGameMessage(message.data.payload);
+      if (incoming.confirmed) {
+        this.sendMessage({
+          type: CommunicationDataType.GAME_ACTION_HOSTER,
+          data: {
+            to: message.data.from,
+            payload: this.createGameMessageAcknowledgement(incoming.messageId),
+          },
+        });
+        normalizedMessage = {
+          ...message,
+          data: {
+            ...message.data,
+            payload: incoming.payload,
+          },
+        };
+      }
+    }
+
+    super.messageHandler(normalizedMessage);
+
+    if (normalizedMessage.type === CommunicationDataType.GAME_ACTION_RESPONSE_HOSTER) {
+      this.gameMessageListeners.forEach((callbackfn) =>
+        callbackfn.listener(normalizedMessage),
+      );
       return;
     }
   }

--- a/src/hoster/SmartPlayerModel.ts
+++ b/src/hoster/SmartPlayerModel.ts
@@ -1,6 +1,10 @@
 import { makeAutoObservable, reaction } from 'mobx';
 
-import { GameDataDefinition } from '@/common/CommunicationDataTransfers';
+import {
+  GameDataDefinition,
+  GameMessageDeliveryOptions,
+  GameMessageDeliveryReceipt,
+} from '@/common/CommunicationDataTransfers';
 
 import { PlayerModel } from '../common/models/PlayerModel';
 import { HosterCommunicator } from './HosterCommunicator';
@@ -82,9 +86,22 @@ export class SmartPlayerModel<TGameData extends GameDataDefinition> {
    * Sends a typed game payload only to this player.
    *
    * @param data Payload from the game's `HosterToController` contract.
+   * @param options Optional delivery-confirmation settings.
    */
-  sendMessage(data: TGameData['HosterToController']) {
-    return this.hosterCommunicator.sendGameMessage(data, this.connectionId);
+  sendMessage(data: TGameData['HosterToController']): void;
+  sendMessage(
+    data: TGameData['HosterToController'],
+    options: GameMessageDeliveryOptions,
+  ): Promise<GameMessageDeliveryReceipt>;
+  sendMessage(
+    data: TGameData['HosterToController'],
+    options?: GameMessageDeliveryOptions,
+  ): void | Promise<GameMessageDeliveryReceipt> {
+    if (options) {
+      return this.hosterCommunicator.sendGameMessage(data, this.connectionId, options);
+    }
+
+    this.hosterCommunicator.sendGameMessage(data, this.connectionId);
   }
 
   /**

--- a/test/src/message-delivery.test.ts
+++ b/test/src/message-delivery.test.ts
@@ -1,0 +1,386 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CommunicationDataType,
+  ControllerCommunicator,
+  GameMessageDeliveryError,
+  HosterCommunicator,
+  PlayerDto,
+  Subscription,
+} from '@/index';
+
+interface TestGameData {
+  ControllerToHoster: { action: string };
+  HosterToController: { notice: string };
+}
+
+function createPlayerDto(
+  connectionId: string,
+  overrides: Partial<PlayerDto> = {},
+): PlayerDto {
+  return {
+    screenName: connectionId,
+    connectionId,
+    image: null,
+    ready: true,
+    active: true,
+    hasConnection: true,
+    isHost: false,
+    subscription: Subscription.Free,
+    ...overrides,
+  };
+}
+
+describe('game message delivery confirmation', () => {
+  const postMessage = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      parent: { postMessage },
+    });
+    postMessage.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps ordinary controller messages fire-and-forget and unwrapped', () => {
+    const communicator = new ControllerCommunicator<TestGameData>();
+    postMessage.mockClear();
+
+    const result = communicator.sendGameMessage({ action: 'buzz' });
+
+    expect(result).toBeUndefined();
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: CommunicationDataType.GAME_ACTION_CONTROLLER,
+        data: { payload: { action: 'buzz' } },
+      },
+      '*',
+    );
+
+    communicator.destructor();
+  });
+
+  it('resolves a controller delivery promise when the host acknowledges it', async () => {
+    const communicator = new ControllerCommunicator<TestGameData>();
+    postMessage.mockClear();
+
+    const delivery = communicator.sendGameMessage(
+      { action: 'buzz' },
+      { timeoutMs: 1_000 },
+    );
+    const outbound = postMessage.mock.calls[0]?.[0];
+    const messageId = outbound.data.payload.__tpgCoreDelivery.messageId;
+
+    communicator.messageHandler({
+      type: CommunicationDataType.GAME_ACTION_RESPONSE_CONTROLLER,
+      data: {
+        payload: {
+          __tpgCoreDelivery: {
+            version: 1,
+            kind: 'acknowledgement',
+            messageId,
+          },
+        },
+      },
+    });
+
+    await expect(delivery).resolves.toEqual({
+      messageId,
+      recipientId: 'hoster',
+      confirmedAt: 10_000,
+    });
+
+    communicator.destructor();
+  });
+
+  it('unwraps a confirmed host message, acknowledges it, and hides protocol traffic', () => {
+    const communicator = new ControllerCommunicator<TestGameData>();
+    const onMessage = vi.fn();
+    communicator.addGameMessageListener(onMessage);
+    postMessage.mockClear();
+
+    communicator.messageHandler({
+      type: CommunicationDataType.GAME_ACTION_RESPONSE_CONTROLLER,
+      data: {
+        payload: {
+          __tpgCoreDelivery: {
+            version: 1,
+            kind: 'message',
+            messageId: 'host-message-1',
+          },
+          payload: { notice: 'Next round' },
+        },
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledOnce();
+    expect(onMessage).toHaveBeenCalledWith({
+      payload: { notice: 'Next round' },
+    });
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: CommunicationDataType.GAME_ACTION_CONTROLLER,
+        data: {
+          payload: {
+            __tpgCoreDelivery: {
+              version: 1,
+              kind: 'acknowledgement',
+              messageId: 'host-message-1',
+            },
+          },
+        },
+      },
+      '*',
+    );
+
+    communicator.messageHandler({
+      type: CommunicationDataType.GAME_ACTION_RESPONSE_CONTROLLER,
+      data: {
+        payload: {
+          __tpgCoreDelivery: {
+            version: 1,
+            kind: 'acknowledgement',
+            messageId: 'unknown-message',
+          },
+        },
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledOnce();
+    communicator.destructor();
+  });
+
+  it('waits for every connected host broadcast recipient', async () => {
+    const communicator = new HosterCommunicator<TestGameData>();
+    communicator.playerStore.smartUpdatePlayers([
+      createPlayerDto('player-1'),
+      createPlayerDto('player-2'),
+      createPlayerDto('offline-player', { hasConnection: false }),
+    ]);
+    postMessage.mockClear();
+
+    const delivery = communicator.broadcastGameMessage(
+      { notice: 'Vote now' },
+      { timeoutMs: 1_000 },
+    );
+    const outboundMessages = postMessage.mock.calls.map(([message]) => message);
+
+    expect(outboundMessages).toHaveLength(2);
+    expect(outboundMessages.map((message) => message.data.to)).toEqual([
+      'player-1',
+      'player-2',
+    ]);
+
+    for (const outbound of outboundMessages.toReversed()) {
+      communicator.messageHandler({
+        type: CommunicationDataType.GAME_ACTION_RESPONSE_HOSTER,
+        data: {
+          from: outbound.data.to,
+          payload: {
+            __tpgCoreDelivery: {
+              version: 1,
+              kind: 'acknowledgement',
+              messageId: outbound.data.payload.__tpgCoreDelivery.messageId,
+            },
+          },
+        },
+      });
+    }
+
+    await expect(delivery).resolves.toEqual([
+      {
+        messageId: outboundMessages[0].data.payload.__tpgCoreDelivery.messageId,
+        recipientId: 'player-1',
+        confirmedAt: 10_000,
+      },
+      {
+        messageId: outboundMessages[1].data.payload.__tpgCoreDelivery.messageId,
+        recipientId: 'player-2',
+        confirmedAt: 10_000,
+      },
+    ]);
+
+    communicator.destructor();
+  });
+
+  it('accepts a host delivery acknowledgement only from its target player', async () => {
+    const communicator = new HosterCommunicator<TestGameData>();
+    communicator.playerStore.smartUpdatePlayers([
+      createPlayerDto('player-1'),
+      createPlayerDto('player-2'),
+    ]);
+    postMessage.mockClear();
+
+    const delivery = communicator.sendGameMessage(
+      { notice: 'Private message' },
+      'player-1',
+      { timeoutMs: 1_000 },
+    );
+    const outbound = postMessage.mock.calls[0]?.[0];
+    const messageId = outbound.data.payload.__tpgCoreDelivery.messageId;
+    const acknowledgement = {
+      __tpgCoreDelivery: {
+        version: 1,
+        kind: 'acknowledgement',
+        messageId,
+      },
+    };
+
+    communicator.messageHandler({
+      type: CommunicationDataType.GAME_ACTION_RESPONSE_HOSTER,
+      data: {
+        from: 'player-2',
+        payload: acknowledgement,
+      },
+    });
+
+    let settled = false;
+    void delivery.finally(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    communicator.messageHandler({
+      type: CommunicationDataType.GAME_ACTION_RESPONSE_HOSTER,
+      data: {
+        from: 'player-1',
+        payload: acknowledgement,
+      },
+    });
+
+    await expect(delivery).resolves.toMatchObject({
+      messageId,
+      recipientId: 'player-1',
+    });
+
+    communicator.destructor();
+  });
+
+  it('unwraps and acknowledges a confirmed controller message on the host', () => {
+    const communicator = new HosterCommunicator<TestGameData>();
+    const onMessage = vi.fn();
+    communicator.addGameMessageListener(onMessage);
+    postMessage.mockClear();
+
+    communicator.messageHandler({
+      type: CommunicationDataType.GAME_ACTION_RESPONSE_HOSTER,
+      data: {
+        from: 'player-1',
+        payload: {
+          __tpgCoreDelivery: {
+            version: 1,
+            kind: 'message',
+            messageId: 'controller-message-1',
+          },
+          payload: { action: 'buzz' },
+        },
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledOnce();
+    expect(onMessage).toHaveBeenCalledWith({
+      from: 'player-1',
+      payload: { action: 'buzz' },
+    });
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: CommunicationDataType.GAME_ACTION_HOSTER,
+        data: {
+          to: 'player-1',
+          payload: {
+            __tpgCoreDelivery: {
+              version: 1,
+              kind: 'acknowledgement',
+              messageId: 'controller-message-1',
+            },
+          },
+        },
+      },
+      '*',
+    );
+
+    communicator.destructor();
+  });
+
+  it('rejects on timeout and when a host recipient is unavailable', async () => {
+    const controller = new ControllerCommunicator<TestGameData>();
+    postMessage.mockClear();
+    const timedOut = controller.sendGameMessage({ action: 'buzz' }, { timeoutMs: 250 });
+    const timedOutExpectation = expect(timedOut).rejects.toMatchObject({
+      name: 'GameMessageDeliveryError',
+      code: 'timeout',
+      recipientId: 'hoster',
+      timeoutMs: 250,
+    } satisfies Partial<GameMessageDeliveryError>);
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    await timedOutExpectation;
+    controller.destructor();
+
+    const hoster = new HosterCommunicator<TestGameData>();
+    hoster.playerStore.smartUpdatePlayers([
+      createPlayerDto('offline-player', { hasConnection: false }),
+    ]);
+    postMessage.mockClear();
+
+    await expect(
+      hoster.sendGameMessage({ notice: 'Next round' }, 'offline-player', {
+        timeoutMs: 250,
+      }),
+    ).rejects.toMatchObject({
+      name: 'GameMessageDeliveryError',
+      code: 'recipient-unavailable',
+      recipientId: 'offline-player',
+    } satisfies Partial<GameMessageDeliveryError>);
+    expect(postMessage).not.toHaveBeenCalled();
+
+    hoster.playerStore.smartUpdatePlayers([createPlayerDto('connected-player')]);
+    postMessage.mockClear();
+    const disconnected = hoster.sendGameMessage(
+      { notice: 'Next round' },
+      'connected-player',
+      { timeoutMs: 1_000 },
+    );
+    const disconnectedExpectation = expect(disconnected).rejects.toMatchObject({
+      name: 'GameMessageDeliveryError',
+      code: 'recipient-unavailable',
+      recipientId: 'connected-player',
+    } satisfies Partial<GameMessageDeliveryError>);
+
+    hoster.playerStore.smartUpdatePlayers([
+      createPlayerDto('connected-player', { hasConnection: false }),
+    ]);
+
+    await disconnectedExpectation;
+    hoster.destructor();
+  });
+
+  it('rejects and cleans up pending confirmations on destruction', async () => {
+    const communicator = new ControllerCommunicator<TestGameData>();
+    postMessage.mockClear();
+    const delivery = communicator.sendGameMessage(
+      { action: 'buzz' },
+      { timeoutMs: 10_000 },
+    );
+
+    communicator.destructor();
+
+    await expect(delivery).rejects.toMatchObject({
+      name: 'GameMessageDeliveryError',
+      code: 'communicator-destroyed',
+      recipientId: 'hoster',
+    } satisfies Partial<GameMessageDeliveryError>);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+  });
+});

--- a/test/src/message-delivery.test.ts
+++ b/test/src/message-delivery.test.ts
@@ -33,10 +33,27 @@ function createPlayerDto(
 
 describe('game message delivery confirmation', () => {
   const postMessage = vi.fn();
+  let installedPromiseWithResolvers = false;
 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);
+    if (!Promise.withResolvers) {
+      Object.defineProperty(Promise, 'withResolvers', {
+        configurable: true,
+        value: <T>() => {
+          let resolve!: (value: T | PromiseLike<T>) => void;
+          let reject!: (reason?: unknown) => void;
+          const promise = new Promise<T>((promiseResolve, promiseReject) => {
+            resolve = promiseResolve;
+            reject = promiseReject;
+          });
+
+          return { promise, resolve, reject };
+        },
+      });
+      installedPromiseWithResolvers = true;
+    }
     vi.stubGlobal('window', {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
@@ -46,6 +63,10 @@ describe('game message delivery confirmation', () => {
   });
 
   afterEach(() => {
+    if (installedPromiseWithResolvers) {
+      Reflect.deleteProperty(Promise, 'withResolvers');
+      installedPromiseWithResolvers = false;
+    }
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });

--- a/test/src/player-models.test.ts
+++ b/test/src/player-models.test.ts
@@ -86,9 +86,15 @@ describe('SmartPlayerModel', () => {
 
     smartPlayer.sendMessage({ notice: 'Next round' });
 
-    expect(sendGameMessage).toHaveBeenCalledWith(
-      { notice: 'Next round' },
+    expect(sendGameMessage).toHaveBeenCalledWith({ notice: 'Next round' }, 'player-1');
+
+    const options = { timeoutMs: 1_000 };
+    smartPlayer.sendMessage({ notice: 'Confirmed round' }, options);
+
+    expect(sendGameMessage).toHaveBeenLastCalledWith(
+      { notice: 'Confirmed round' },
       'player-1',
+      options,
     );
   });
 


### PR DESCRIPTION
Closes #295

## What changed

- add an optional delivery-confirmation argument to controller, host, broadcast, and smart-player game-message APIs
- preserve existing fire-and-forget calls and raw payloads by default
- resolve confirmed sends only after the receiving game iframe acknowledges them
- reject with typed timeout, unavailable-recipient, or communicator-destroyed errors
- wait for every connected recipient during confirmed broadcasts and authenticate host-side acknowledgements against the target player
- document the compatibility requirement and reserved protocol field
- use the repository's established `Promise.withResolvers` test shim so the new communicator tests run on the Node 20 CI target

## Verification

- `npx -y node@20.10.0 ./node_modules/vitest/vitest.mjs run --coverage` — passed (32 tests) in the exact hosted Node version
- `corepack yarn vitest run test/src/message-delivery.test.ts test/src/player-models.test.ts` — passed (14 tests)
- `corepack yarn vitest run` — passed (32 tests)
- `corepack yarn build` — passed, including declaration generation
- `corepack yarn lint:check` — passed
- changed-file Prettier check — passed
- `git diff --check` — passed
- targeted source-and-test TypeScript project — passed
- `corepack yarn type-check` — repository baseline failure: TS6305 for `vite.config.d.ts` because the root config includes `vite.config.ts` while referencing `tsconfig.node.json`; unrelated to this patch

## Demo

Non-visual library change; screenshots and screencasts are not applicable. Reproduce with `corepack yarn vitest run test/src/message-delivery.test.ts`, which exercises controller-to-host, host-to-controller, multi-recipient broadcast, timeout, disconnect, spoofed acknowledgement, and cleanup behavior.